### PR TITLE
Null Handler Prevents Crash

### DIFF
--- a/JAVS.TFTP/Transfer/States/AcknowledgeWriteRequest.cs
+++ b/JAVS.TFTP/Transfer/States/AcknowledgeWriteRequest.cs
@@ -30,5 +30,9 @@ namespace Tftp.Net.Transfer.States
         {
             Context.SetState(new ReceivedError(command));
         }
+
+        public override void OnOptionAcknowledgement(OptionAcknowledgement command)
+        {
+        }
     }
 }

--- a/JAVS.TFTP/Transfer/States/Receiving.cs
+++ b/JAVS.TFTP/Transfer/States/Receiving.cs
@@ -58,5 +58,9 @@ namespace Tftp.Net.Transfer.States
             Context.GetConnection().Send(ack);
             ResetTimeout();
         }
+
+        public override void OnOptionAcknowledgement(OptionAcknowledgement command)
+        {
+        }
     }
 }

--- a/JAVS.TFTP/Transfer/States/SendOptionAcknowledgementBase.cs
+++ b/JAVS.TFTP/Transfer/States/SendOptionAcknowledgementBase.cs
@@ -24,5 +24,9 @@ namespace Tftp.Net.Transfer
         {
             Context.SetState(new CancelledByUser(reason));
         }
+
+        public override void OnOptionAcknowledgement(OptionAcknowledgement command)
+        {
+        }
     }
 }

--- a/JAVS.TFTP/Transfer/States/Sending.cs
+++ b/JAVS.TFTP/Transfer/States/Sending.cs
@@ -73,6 +73,9 @@ namespace Tftp.Net.Transfer.States
             SendAndRepeat(dataCommand);
         }
 
+        public override void OnOptionAcknowledgement(OptionAcknowledgement command)
+        {
+        }
         #endregion
     }
 }


### PR DESCRIPTION
When the initial "write" fails and has to retry, apparently somebody triggers a "negotiation result" message. The NotImplemented Exception stops the transfer for some reason. Implementing the null handler in all cases fixes the crash and allows for error recovery.
